### PR TITLE
Use FORCE INDEX on FROM clausule

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -543,7 +543,7 @@ class SQLCompiler(object):
                 else:
                     extra_sql = ""
                 for model, hint in self.query.hints.items():
-                    if model == name:
+                    if model == name and hasattr(self.connection, 'mysql_version'):
                         part = ' FORCE INDEX (%s)' % ', '.join([qn(h) for h in hint])
                         result.append('%s %s%s %s ON ('% (join_type, qn(name), alias_str, part))
                         break

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -557,7 +557,13 @@ class SQLCompiler(object):
                 result.append('%s)' % extra_sql)
             else:
                 connector = '' if first else ', '
-                result.append('%s%s%s' % (connector, qn(name), alias_str))
+                for model, hint in self.query.hints.items():
+                    if model == name and hasattr(self.connection, 'mysql_version'):
+                        part = ' FORCE INDEX (%s)' % ', '.join([qn(h) for h in hint])
+                        result.append('%s %s%s %s '% (connector, qn(name), alias_str, part))
+                        break
+                else:
+                    result.append('%s%s%s' % (connector, qn(name), alias_str))
             first = False
         for t in self.query.extra_tables:
             alias, unused = self.query.table_alias(t)


### PR DESCRIPTION
Zjistili jsme, že funcionalita `FORCE INDEX` se aktuálně koná pouze nad tabulkami, které se připojují přes `JOIN` klauzuli. Tato úprava umožňuje využítí této funkcionality i nad tabulkou nad kterou se dotaz vyvolává - `FROM` klauzule.
Prosím merge nebo merge právo do master větve.
Dík
P.S. This is my first pull request ever!